### PR TITLE
Refactor to detach getNow from synth

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ a WebAudio subtractive, monophonic synthesizer
 ### create a synth
 ```
 var audioCtx = new AudioContext();
-var synth = new Monosynth(audioCtx);
+var synth = submono.createSynth(audioCtx);
 ```
 
 ### play a note
@@ -39,7 +39,7 @@ var config = {
   }
 };
 
-var synth = new Monosynth(audioCtx, config);
+var synth = submono.createSynth(audioCtx, config);
 ```
 
 ### demo

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ a WebAudio subtractive, monophonic synthesizer
 ### create a synth
 ```
 var audioCtx = new AudioContext();
-var synth = submono.createSynth(audioCtx);
+var synth = new Monosynth(audioCtx);
 ```
 
 ### play a note
@@ -39,7 +39,7 @@ var config = {
   }
 };
 
-var synth = submono.createSynth(audioCtx, config);
+var synth = new Monosynth(audioCtx, config);
 ```
 
 ### demo

--- a/submono.js
+++ b/submono.js
@@ -8,23 +8,32 @@
  * TODO: Explore synth.cutoff.contour.
  */
 
-var submono = {
-  createSynth: function(audioCtx, config) {
+var Monosynth = function Monosynth(audioCtx, config) {
+
+  var Synth = function Synth() {
     config = config || {};
     config.cutoff = config.cutoff || {};
-    
-    var synth = {
-      audioCtx: audioCtx,
-      amp:      audioCtx.createGain(),
-      filter:   audioCtx.createBiquadFilter(),
-      osc:      audioCtx.createOscillator(),
-      pan:      audioCtx.createPanner(),
-      maxGain:  config.maxGain  || 0.9, // out of 1
-      attack:   config.attack   || 0.1, // in seconds
-      decay:    config.decay    || 0.0, // in seconds
-      sustain:  config.sustain  || 1.0, // out of 1
-      release:  config.release  || 0.8, // in seconds
-    };
+
+    var synth = this;
+
+    synth.audioCtx = audioCtx,
+    synth.amp      = audioCtx.createGain(),
+    synth.filter   = audioCtx.createBiquadFilter(),
+    synth.osc      = audioCtx.createOscillator(),
+    synth.pan      = audioCtx.createPanner(),
+
+    synth.maxGain  = config.maxGain  || 0.9, // out of 1
+    synth.attack   = config.attack   || 0.1, // in seconds
+    synth.decay    = config.decay    || 0.0, // in seconds
+    synth.sustain  = config.sustain  || 1.0, // out of 1
+    synth.release  = config.release  || 0.8, // in seconds
+
+    //low-pass filter
+    synth.cutoff              = synth.filter.frequency;
+    synth.cutoff.maxFrequency = config.cutoff.maxFrequency || 7500; // in hertz
+    synth.cutoff.attack       = config.cutoff.attack       || 0.1; // in seconds
+    synth.cutoff.decay        = config.cutoff.decay        || 2.5; // in seconds
+    synth.cutoff.sustain      = config.cutoff.sustain      || 0.2; // out of 1
     
     synth.amp.gain.value = 0;
     synth.filter.type = 'lowpass';
@@ -36,60 +45,55 @@ var submono = {
     synth.pan.connect(synth.filter);
     synth.osc.start(0);
     
-    //low-pass filter
-    synth.cutoff              = synth.filter.frequency;
-    synth.cutoff.maxFrequency = config.cutoff.maxFrequency || 7500; // in hertz
-    synth.cutoff.attack       = config.cutoff.attack       || 0.1; // in seconds
-    synth.cutoff.decay        = config.cutoff.decay        || 2.5; // in seconds
-    synth.cutoff.sustain      = config.cutoff.sustain      || 0.2; // out of 1
-    
-    function getNow() {
-      var now = synth.audioCtx.currentTime;
-      synth.amp.gain.cancelScheduledValues(now);
-      synth.amp.gain.setValueAtTime(synth.amp.gain.value, now);
-      return now;
-    };
-
-    synth.pitch = function pitch(newPitch) {
-      if (newPitch) {
-        var now = synth.audioCtx.currentTime;
-        synth.osc.frequency.setValueAtTime(newPitch, now);
-      }
-      return synth.osc.frequency.value;
-    };
-
-    synth.waveform = function waveform(newWaveform) {
-      if (newWaveform) {
-        synth.osc.type = newWaveform;
-      }
-      return synth.osc.type;
-    };
-
-    //apply attack, decay, sustain envelope
-    synth.start = function startSynth() {
-      var atk  = parseFloat(synth.attack);
-      var dec  = parseFloat(synth.decay);
-      var cAtk = parseFloat(synth.cutoff.attack);
-      var cDec = parseFloat(synth.cutoff.decay);
-      var now  = getNow();
-      synth.cutoff.cancelScheduledValues(now);
-      synth.cutoff.linearRampToValueAtTime(synth.cutoff.value, now);
-      synth.cutoff.linearRampToValueAtTime(synth.cutoff.maxFrequency, now + cAtk);
-      synth.cutoff.linearRampToValueAtTime(synth.cutoff.sustain * synth.cutoff.maxFrequency, now + cAtk + cDec);
-      synth.amp.gain.linearRampToValueAtTime(synth.maxGain, now + atk);
-      synth.amp.gain.linearRampToValueAtTime(synth.sustain * synth.maxGain, now + atk + dec);
-    };
-
-    //apply release envelope
-    synth.stop = function stopSynth() {
-      var rel = parseFloat(synth.release);
-      var now = getNow();
-      synth.amp.gain.linearRampToValueAtTime(0, now + rel);
-    };
-
     synth.waveform(config.waveform || 'sine');
     synth.pitch(config.pitch || 440);
-    
+
     return synth;
-  }
+  };
+
+  function getNow() {
+    var now = this.audioCtx.currentTime;
+    this.amp.gain.cancelScheduledValues(now);
+    this.amp.gain.setValueAtTime(this.amp.gain.value, now);
+    return now;
+  };
+  
+  Synth.prototype.pitch = function pitch(newPitch) {
+    if (newPitch) {
+      var now = this.audioCtx.currentTime;
+      this.osc.frequency.setValueAtTime(newPitch, now);
+    }
+    return this.osc.frequency.value;
+  };
+
+  Synth.prototype.waveform = function waveform(newWaveform) {
+    if (newWaveform) {
+      this.osc.type = newWaveform;
+    }
+    return this.osc.type;
+  };
+
+  //apply attack, decay, sustain envelope
+  Synth.prototype.start = function startSynth() {
+    var atk  = parseFloat(this.attack);
+    var dec  = parseFloat(this.decay);
+    var cAtk = parseFloat(this.cutoff.attack);
+    var cDec = parseFloat(this.cutoff.decay);
+    var now  = getNow.bind(this)();
+    this.cutoff.cancelScheduledValues(now);
+    this.cutoff.linearRampToValueAtTime(this.cutoff.value, now);
+    this.cutoff.linearRampToValueAtTime(this.cutoff.maxFrequency, now + cAtk);
+    this.cutoff.linearRampToValueAtTime(this.cutoff.sustain * this.cutoff.maxFrequency, now + cAtk + cDec);
+    this.amp.gain.linearRampToValueAtTime(this.maxGain, now + atk);
+    this.amp.gain.linearRampToValueAtTime(this.sustain * this.maxGain, now + atk + dec);
+  };
+
+  //apply release envelope
+  Synth.prototype.stop = function stopSynth() {
+    var rel = parseFloat(this.release);
+    var now = getNow.bind(this)();
+    this.amp.gain.linearRampToValueAtTime(0, now + rel);
+  };
+
+  return new Synth;
 };

--- a/submono.js
+++ b/submono.js
@@ -8,96 +8,88 @@
  * TODO: Explore synth.cutoff.contour.
  */
 
-var Monosynth = function(audioCtx, config) {
+var submono = {
+  createSynth: function(audioCtx, config) {
+    config = config || {};
+    config.cutoff = config.cutoff || {};
+    
+    var synth = {
+      audioCtx: audioCtx,
+      amp:      audioCtx.createGain(),
+      filter:   audioCtx.createBiquadFilter(),
+      osc:      audioCtx.createOscillator(),
+      pan:      audioCtx.createPanner(),
+      maxGain:  config.maxGain  || 0.9, // out of 1
+      attack:   config.attack   || 0.1, // in seconds
+      decay:    config.decay    || 0.0, // in seconds
+      sustain:  config.sustain  || 1.0, // out of 1
+      release:  config.release  || 0.8, // in seconds
+    };
+    
+    synth.amp.gain.value = 0;
+    synth.filter.type = 'lowpass';
+    synth.filter.connect(synth.amp);
+    synth.amp.connect(audioCtx.destination);
+    synth.pan.panningModel = 'equalpower';
+    synth.pan.setPosition(0, 0, 1); // start with stereo image centered
+    synth.osc.connect(synth.pan);
+    synth.pan.connect(synth.filter);
+    synth.osc.start(0);
+    
+    //low-pass filter
+    synth.cutoff              = synth.filter.frequency;
+    synth.cutoff.maxFrequency = config.cutoff.maxFrequency || 7500; // in hertz
+    synth.cutoff.attack       = config.cutoff.attack       || 0.1; // in seconds
+    synth.cutoff.decay        = config.cutoff.decay        || 2.5; // in seconds
+    synth.cutoff.sustain      = config.cutoff.sustain      || 0.2; // out of 1
+    
+    function getNow() {
+      var now = synth.audioCtx.currentTime;
+      synth.amp.gain.cancelScheduledValues(now);
+      synth.amp.gain.setValueAtTime(synth.amp.gain.value, now);
+      return now;
+    };
 
-  var synth = this;
-  config = config || {};
-  config.cutoff = config.cutoff || {};
-  
-  synth.audioCtx = audioCtx;
-  synth.amp = audioCtx.createGain();
-  synth.filter = audioCtx.createBiquadFilter();
+    synth.pitch = function pitch(newPitch) {
+      if (newPitch) {
+        var now = synth.audioCtx.currentTime;
+        synth.osc.frequency.setValueAtTime(newPitch, now);
+      }
+      return synth.osc.frequency.value;
+    };
 
-  synth.amp.gain.value = 0;
-  synth.filter.type = 'lowpass';
-  synth.filter.connect(synth.amp);
-  synth.amp.connect(audioCtx.destination);
+    synth.waveform = function waveform(newWaveform) {
+      if (newWaveform) {
+        synth.osc.type = newWaveform;
+      }
+      return synth.osc.type;
+    };
 
-  //synth defaults
-  var defaultWaveform = config.waveform     || 'sine';
-  var defaultPitch    = config.pitch        || 440;
-  
-  synth.maxGain       = config.maxGain      || 0.9; //out of 1
-  synth.attack        = config.attack       || 0.1; //in seconds
-  synth.decay         = config.decay        || 0.0; //in seconds
-  synth.sustain       = config.sustain      || 1.0; //out of 1
-  synth.release       = config.release      || 0.8; //in seconds
-  
-  //low-pass filter cutoff defaults
-  synth.cutoff              = synth.filter.frequency;
-  synth.cutoff.maxFrequency = config.cutoff.maxFrequency || 7500; //in hertz
-  synth.cutoff.attack       = config.cutoff.attack       || 0.1; //in seconds
-  synth.cutoff.decay        = config.cutoff.decay        || 2.5; //in seconds
-  synth.cutoff.sustain      = config.cutoff.sustain      || 0.2; //out of 1
-  
-  //create and connect oscillator and stereo panner
-  synth.osc = audioCtx.createOscillator();
-  synth.pan = audioCtx.createPanner();
-  synth.pan.panningModel = 'equalpower';
-  synth.pan.setPosition(0, 0, 1); // start with stereo image centered
-  synth.osc.connect(this.pan);
-  synth.pan.connect(synth.filter);
-  synth.osc.start(0);
+    //apply attack, decay, sustain envelope
+    synth.start = function startSynth() {
+      var atk  = parseFloat(synth.attack);
+      var dec  = parseFloat(synth.decay);
+      var cAtk = parseFloat(synth.cutoff.attack);
+      var cDec = parseFloat(synth.cutoff.decay);
+      var now  = getNow();
+      synth.cutoff.cancelScheduledValues(now);
+      synth.cutoff.linearRampToValueAtTime(synth.cutoff.value, now);
+      synth.cutoff.linearRampToValueAtTime(synth.cutoff.maxFrequency, now + cAtk);
+      synth.cutoff.linearRampToValueAtTime(synth.cutoff.sustain * synth.cutoff.maxFrequency, now + cAtk + cDec);
+      synth.amp.gain.linearRampToValueAtTime(synth.maxGain, now + atk);
+      synth.amp.gain.linearRampToValueAtTime(synth.sustain * synth.maxGain, now + atk + dec);
+    };
 
-  synth.pitch(defaultPitch);
-  synth.waveform(defaultWaveform);
+    //apply release envelope
+    synth.stop = function stopSynth() {
+      var rel = parseFloat(synth.release);
+      var now = getNow();
+      synth.amp.gain.linearRampToValueAtTime(0, now + rel);
+    };
 
-  return synth;
-
-};
-
-Monosynth.prototype.getNow = function getNow() {
-  var now = this.audioCtx.currentTime;
-  this.amp.gain.cancelScheduledValues(now);
-  this.amp.gain.setValueAtTime(this.amp.gain.value, now);
-  return now;
-};
-
-Monosynth.prototype.pitch = function pitch(newPitch) {
-  if (newPitch) {
-    var now = this.audioCtx.currentTime;
-    this.osc.frequency.setValueAtTime(newPitch, now);
+    synth.waveform(config.waveform || 'sine');
+    synth.pitch(config.pitch || 440);
+    
+    return synth;
   }
-
-  return this.osc.frequency.value;
-};
-
-Monosynth.prototype.waveform = function waveform(newWaveform) {
-  if (newWaveform) {
-    this.osc.type = newWaveform;
-  }
-
-  return this.osc.type;
-};
-
-//apply attack, decay, sustain envelope
-Monosynth.prototype.start = function startSynth() {
-  var atk  = parseFloat(this.attack);
-  var dec  = parseFloat(this.decay);
-  var cAtk = parseFloat(this.cutoff.attack);
-  var cDec = parseFloat(this.cutoff.decay);
-  var now  = this.getNow();
-  this.cutoff.cancelScheduledValues(now);
-  this.cutoff.linearRampToValueAtTime(this.cutoff.value, now);
-  this.cutoff.linearRampToValueAtTime(this.cutoff.maxFrequency, now + cAtk);
-  this.cutoff.linearRampToValueAtTime(this.cutoff.sustain * this.cutoff.maxFrequency, now + cAtk + cDec);
-  this.amp.gain.linearRampToValueAtTime(this.maxGain, now + atk);
-  this.amp.gain.linearRampToValueAtTime(this.sustain * this.maxGain, now + atk + dec);
-};
-
-//apply release envelope
-Monosynth.prototype.stop = function stopSynth() {
-  var rel = parseFloat(this.release);
-  var now = this.getNow();
-  this.amp.gain.linearRampToValueAtTime(0, now + rel);
 };


### PR DESCRIPTION
Refactor to detach `getNow` from synth.

Branched off of another refactor I wrote to avoid the `new` keyword, but decided against that path. Disadvantage was a larger memory footprint due to not using prototype functions. I also prefer the syntax `var synth = new Monosynth()` versus `var synth = submono.createSynth()`.

I'm not crazy about the new nested constructors, but I don't know of another way to keep getNow private... should look into that at some point.
